### PR TITLE
Lower required CMake version for compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.4)
 
 if(POLICY CMP0011)
   cmake_policy(SET CMP0011 NEW)


### PR DESCRIPTION
CMake version should be lowered to 3.4 (the same version as in the master branch of pybind11).